### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,9 @@ APIVERSION = 1
 #LDFLAGS = -Wl,--no-undefined
 CFLAGS ?= -Os
 #CFLAGS = -g -O0
-CFLAGS += -fPIC
-CFLAGS += -Wall
-CFLAGS += -Wextra
-CFLAGS += -DENABLE_STRNATPMPERR
+override CFLAGS += -Wall
+override CFLAGS += -Wextra
+override CFLAGS += -fPIC -DENABLE_STRNATPMPERR
 
 LIBOBJS = natpmp.o getgateway.o
 


### PR DESCRIPTION
Preclude cflags overriding.

Fedora has %optflags for building, if I use CFLAGS="%{optflags}" during building, it will override the fPIC and custom flags defined, and it's incorrect. Therefore we should avoid that issue.
