### PR TITLE
py: build libnatpmp.a

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,23 @@
 # $Id: setup.py,v 1.3 2012/03/05 04:54:01 nanard Exp $
 #
 # python script to build the libnatpmp module under unix
-#
-# replace libnatpmp.a by libnatpmp.so for shared library usage
-from distutils.core import setup, Extension
-from distutils import sysconfig
-sysconfig.get_config_vars()["OPT"] = ''
-sysconfig.get_config_vars()["CFLAGS"] = ''
+
+from setuptools import setup, Extension
+from setuptools.command import build_ext
+import subprocess
+
+EXT = ['libnatpmp.a']
+
+class make_then_build_ext(build_ext.build_ext):
+      def run(self):
+            subprocess.check_call(['make'] + EXT)
+            build_ext.build_ext.run(self)
+
 setup(name="libnatpmp", version="1.0",
+      cmdclass={'build_ext': make_then_build_ext},
       ext_modules=[
         Extension(name="libnatpmp", sources=["libnatpmpmodule.c"],
-                  extra_objects=["libnatpmp.a"],
+                  extra_objects=EXT,
                   define_macros=[('ENABLE_STRNATPMPERR', None)]
         )]
      )


### PR DESCRIPTION
This allows to build the module directly via `pip`.