### PR TITLE
Use Winsock definition for errno values rather than the POSIX ones

### DIFF
--- a/natpmp.c
+++ b/natpmp.c
@@ -39,12 +39,14 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <io.h>
-#ifndef EWOULDBLOCK
+#ifdef EWOULDBLOCK
+#undef EWOULDBLOCK
+#endif
+#ifdef ECONNREFUSED
+#undef ECONNREFUSED
+#endif
 #define EWOULDBLOCK WSAEWOULDBLOCK
-#endif
-#ifndef ECONNREFUSED
 #define ECONNREFUSED WSAECONNREFUSED
-#endif
 #include "wingettimeofday.h"
 #define gettimeofday natpmp_gettimeofday
 #else


### PR DESCRIPTION
Modern Windows 10 SDKs have POSIX-compatible errno definitions in errno.h. These definitions match POSIX values, but Winsock uses different values. As a result, libnatpmp doesn't properly recognize WSAEWOULDBLOCK or WSAECONNREFUSED errors when built against the Windows 10 SDK. This prevents the NAT-PMP request retry logic from working properly.