### PR TITLE
make the maximum number of retries configurable at compile time

### DIFF
--- a/natpmp.c
+++ b/natpmp.c
@@ -286,7 +286,7 @@ NATPMP_LIBSPEC int readnatpmpresponseorretry(natpmp_t * p, natpmpresp_t * respon
 			gettimeofday(&now, NULL);	// check errors !
 			if(timercmp(&now, &p->retry_time, >=)) {
 				int delay, r;
-				if(p->try_number >= 9) {
+				if(p->try_number >= NATPMP_MAX_RETRIES) {
 					return NATPMP_ERR_NOGATEWAYSUPPORT;
 				}
 				/*printf("retry! %d\n", p->try_number);*/

--- a/natpmp.h
+++ b/natpmp.h
@@ -51,6 +51,13 @@ typedef unsigned short uint16_t;
 #endif	/* _WIN32 */
 #include "natpmp_declspec.h"
 
+/* Set to 9 by https://tools.ietf.org/html/rfc6886#section-3.1 which leads to a
+ * maximum timeout of 127.75 seconds, due to the initial 250 ms timeout doubling
+ * each time, so we allow a compile-time modification here.*/
+#ifndef NATPMP_MAX_RETRIES
+#define NATPMP_MAX_RETRIES (9)
+#endif
+
 typedef struct {
 	int s;	/* socket */
 	in_addr_t gateway;	/* default gateway (IPv4) */


### PR DESCRIPTION
using a preprocessor define like this: `CFLAGS="-Os -DNATPMP_MAX_RETRIES=4" make`.

The rationale is that users might want to reduce the maximum timeout of 127.75 seconds with an invalid gateway.

You can see this problem in practice by using an unassigned IP for the gateway:

```sh
$ time ./natpmpc-static -g 192.168.1.254
initnatpmp() returned 0 (SUCCESS)
using gateway : 192.168.1.254
sendpublicaddressrequest returned 2 (SUCCESS)
readnatpmpresponseorretry returned -100 (TRY AGAIN)
readnatpmpresponseorretry returned -100 (TRY AGAIN)
readnatpmpresponseorretry returned -100 (TRY AGAIN)
readnatpmpresponseorretry returned -100 (TRY AGAIN)
readnatpmpresponseorretry returned -100 (TRY AGAIN)
readnatpmpresponseorretry returned -100 (TRY AGAIN)
readnatpmpresponseorretry returned -100 (TRY AGAIN)
readnatpmpresponseorretry returned -100 (TRY AGAIN)
readnatpmpresponseorretry returned -7 (FAILED)
readnatpmpresponseorretry() failed : the gateway does not support nat-pmp
  errno=11 'Resource temporarily unavailable'

real	2m7.817s
user	0m0.000s
sys	0m0.004s
$ make clean
$ CFLAGS="-Os -DNATPMP_MAX_RETRIES=4" make
$ time ./natpmpc-static -g 192.168.1.254
initnatpmp() returned 0 (SUCCESS)
using gateway : 192.168.1.254
sendpublicaddressrequest returned 2 (SUCCESS)
readnatpmpresponseorretry returned -100 (TRY AGAIN)
readnatpmpresponseorretry returned -100 (TRY AGAIN)
readnatpmpresponseorretry returned -100 (TRY AGAIN)
readnatpmpresponseorretry returned -7 (FAILED)
  errno=11 'Resource temporarily unavailable'

real	0m3.755s
user	0m0.000s
sys	0m0.003s
```