### PR TITLE
Add missing check for response type and public ip address

### DIFF
--- a/natpmpc.c
+++ b/natpmpc.c
@@ -46,6 +46,45 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif
 #include "natpmp.h"
 
+/* List of IP address blocks which are private / reserved and therefore not suitable for public external IP addresses */
+#define IP(a, b, c, d) (((a) << 24) + ((b) << 16) + ((c) << 8) + (d))
+#define MSK(m) (32-(m))
+static const struct { uint32_t address; uint32_t rmask; } reserved[] = {
+	{ IP(  0,   0,   0, 0), MSK( 8) }, /* RFC1122 "This host on this network" */
+	{ IP( 10,   0,   0, 0), MSK( 8) }, /* RFC1918 Private-Use */
+	{ IP(100,  64,   0, 0), MSK(10) }, /* RFC6598 Shared Address Space */
+	{ IP(127,   0,   0, 0), MSK( 8) }, /* RFC1122 Loopback */
+	{ IP(169, 254,   0, 0), MSK(16) }, /* RFC3927 Link-Local */
+	{ IP(172,  16,   0, 0), MSK(12) }, /* RFC1918 Private-Use */
+	{ IP(192,   0,   0, 0), MSK(24) }, /* RFC6890 IETF Protocol Assignments */
+	{ IP(192,   0,   2, 0), MSK(24) }, /* RFC5737 Documentation (TEST-NET-1) */
+	{ IP(192,  31, 196, 0), MSK(24) }, /* RFC7535 AS112-v4 */
+	{ IP(192,  52, 193, 0), MSK(24) }, /* RFC7450 AMT */
+	{ IP(192,  88,  99, 0), MSK(24) }, /* RFC7526 6to4 Relay Anycast */
+	{ IP(192, 168,   0, 0), MSK(16) }, /* RFC1918 Private-Use */
+	{ IP(192, 175,  48, 0), MSK(24) }, /* RFC7534 Direct Delegation AS112 Service */
+	{ IP(198,  18,   0, 0), MSK(15) }, /* RFC2544 Benchmarking */
+	{ IP(198,  51, 100, 0), MSK(24) }, /* RFC5737 Documentation (TEST-NET-2) */
+	{ IP(203,   0, 113, 0), MSK(24) }, /* RFC5737 Documentation (TEST-NET-3) */
+	{ IP(224,   0,   0, 0), MSK( 4) }, /* RFC1112 Multicast */
+	{ IP(240,   0,   0, 0), MSK( 4) }, /* RFC1112 Reserved for Future Use + RFC919 Limited Broadcast */
+};
+#undef IP
+#undef MSK
+
+static int addr_is_reserved(struct in_addr * addr)
+{
+	uint32_t address = ntohl(addr->s_addr);
+	size_t i;
+
+	for (i = 0; i < sizeof(reserved)/sizeof(reserved[0]); ++i) {
+		if ((address >> reserved[i].rmask) == (reserved[i].address >> reserved[i].rmask))
+			return 1;
+	}
+
+	return 0;
+}
+
 void usage(FILE * out, const char * argv0)
 {
 	fprintf(out, "Usage :\n");
@@ -192,7 +231,16 @@ int main(int argc, char * * argv)
 	if(r<0)
 		return 1;
 
-	/* TODO : check that response.type == 0 */
+	if(response.type!=NATPMP_RESPTYPE_PUBLICADDRESS) {
+		fprintf(stderr, "readnatpmpresponseorretry() failed : invalid response type %u\n", response.type);
+		return 1;
+	}
+
+	if(addr_is_reserved(&response.pnu.publicaddress.addr)) {
+		fprintf(stderr, "readnatpmpresponseorretry() failed : invalid Public IP address %s\n", inet_ntoa(response.pnu.publicaddress.addr));
+		return 1;
+	}
+
 	printf("Public IP address : %s\n", inet_ntoa(response.pnu.publicaddress.addr));
 	printf("epoch = %u\n", response.epoch);
 


### PR DESCRIPTION
This patch adds missing check for response type that response message
payload really contains public ip address structure and also adds checks
that public ip address is valid. Gateway could set public ip address to
zeros on error and client in this case should ignore it. As some broken
gateways announce private/reserved ip addresses in public address field,
check that ip address in received packet is really public to avoid problems
with broken gateways.