### PR TITLE
replaced ssize_t by int64_t

### DIFF
--- a/natpmp.c
+++ b/natpmp.c
@@ -207,7 +207,11 @@ NATPMP_LIBSPEC int readnatpmpresponse(natpmp_t * p, natpmpresp_t * response)
 	unsigned char buf[16];
 	struct sockaddr_in addr;
 	socklen_t addrlen = sizeof(addr);
-	int64_t n;
+#ifdef _WIN32
+        int n;
+#else
+	ssize_t n;
+#endif
 	if(!p)
 		return NATPMP_ERR_INVALIDARGS;
 	n = recvfrom(p->s, buf, sizeof(buf), 0,

--- a/natpmp.c
+++ b/natpmp.c
@@ -207,7 +207,7 @@ NATPMP_LIBSPEC int readnatpmpresponse(natpmp_t * p, natpmpresp_t * response)
 	unsigned char buf[16];
 	struct sockaddr_in addr;
 	socklen_t addrlen = sizeof(addr);
-	ssize_t n;
+	int64_t n;
 	if(!p)
 		return NATPMP_ERR_INVALIDARGS;
 	n = recvfrom(p->s, buf, sizeof(buf), 0,


### PR DESCRIPTION
I found that `ssize_t` is not an easy type to handle on some Windows / build-environment configurations – Windows 10, CMake,  and MS Build Tools 16.8.2 in my case. The issue seems to be related especially to the **signed** part, the corresponding unsigned `size_t` type does not cause any issues.

Instead of conditionally defining or typedef'ing the signed type (which might not even properly work out with each and every MSVC version according to [this](http://www.cplusplus.com/forum/general/82502/#msg442895) somewhat older information) and risking to cause more/new/other issues on other platforms, this pull request replaces the only use of `ssize_t` by `int64_t` which should be widely available with standard integer types.