### PR TITLE
Makefile: Includes natpmp_declspec.h as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ else
 endif
 endif
 
-HEADERS = natpmp.h
+HEADERS = natpmp.h natpmp_declspec.h
 
 EXECUTABLES = testgetgateway natpmpc-shared natpmpc-static
 


### PR DESCRIPTION
Otherwise the header installed would not work.