### PR TITLE
define _DEFAULT_SOURCE along with _BSD_SOURCE

### DIFF
--- a/natpmp.c
+++ b/natpmp.c
@@ -27,7 +27,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 */
 #ifdef __linux__
-#define _BSD_SOURCE 1
+#define _DEFAULT_SOURCE 1
 #endif
 #include <string.h>
 #include <time.h>


### PR DESCRIPTION
`_BSD_SOURCE` is deprecated:
```bash
  148 | # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
```

The simplest fix for suppressing the warnings, if you'd like to retain
the `_BSD_SOURCE` define is to just also define `_DEFAULT_SOURCE`.

See also:
https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html
https://lwn.net/Articles/590381/