### PR TITLE
CMakeLists.txt: Win: fix for case-sensitive filesystems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(natpmp PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 target_compile_definitions(natpmp PRIVATE -DENABLE_STRNATPMPERR)
 
 if (WIN32)
-	target_link_libraries(natpmp PUBLIC ws2_32 Iphlpapi)
+	target_link_libraries(natpmp PUBLIC ws2_32 iphlpapi)
 	target_compile_definitions(natpmp PUBLIC -DNATPMP_STATICLIB)
 endif (WIN32)
 


### PR DESCRIPTION
i.e. MinGW cross-compiler on Linux

fixes:
../lib/gcc/i686-w64-mingw32/11.2.1/../../../../i686-w64-mingw32/bin/ld: cannot find -lIphlpapi