### PR TITLE
CMakeLists.txt: Haiku requires linking to libnetwork

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ if (WIN32)
 	target_compile_definitions(natpmp PUBLIC -DNATPMP_STATICLIB)
 endif (WIN32)
 
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Haiku")
+	target_link_libraries(natpmp PUBLIC network)
+endif ()
+
 # Executables
 add_executable(natpmpc natpmpc.c)
 target_link_libraries(natpmpc natpmp)


### PR DESCRIPTION
fixes:
../../i586-unknown-haiku/bin/ld: natpmp.c:(.text+0x10f): undefined reference to `connect'