### PR TITLE
Fix missing header bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,10 +61,7 @@ install(TARGETS natpmp natpmpc
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-install(FILES natpmp.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
- install(FILES natpmp_declspec.h
+install(FILES natpmp.h natpmp_declspec.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/natpmp.pc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,9 @@ install(TARGETS natpmp natpmpc
 install(FILES natpmp.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
+ install(FILES natpmp_declspec.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/natpmp.pc
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 


### PR DESCRIPTION
The header file natpmp_declspec.h is included by natpmp.h but is not installed in the destination headers folder alongside natpmp.h. As a consequence, any code that includes natpmp.h will fail to compile, AC_CHECK_HEADER will also miss-report the header as not being present for the same reason.

This small fix will ensure the header is copied across when the library is installed.