### PR TITLE
cmake: Drop redundant `cmake_policy` call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
 
-if(POLICY CMP0048)
-	cmake_policy(SET CMP0048 NEW)
-endif()
-
 file(STRINGS VERSION PVER)
 
 project(natpmp


### PR DESCRIPTION
The explicit setting of the [CMP0048](https://cmake.org/cmake/help/latest/policy/CMP0048.html) policy is no longer needed after bumping the minimum required CMake version up to 3.5 in https://github.com/miniupnp/libnatpmp/pull/43.