### PR TITLE
getgateway.c: get correct gateway in OpenBSD

### DIFF
--- a/getgateway.c
+++ b/getgateway.c
@@ -269,6 +269,10 @@ int getdefaultgateway(in_addr_t *addr)
   rtm.rtm_seq = ++seq;
   rtm.rtm_addrs = rtm_addrs;
 
+#ifdef __OpenBSD__
+  rtm.rtm_tableid = getrtable();
+#endif
+
   so_dst.sa_family = AF_INET;
   so_dst.sa_len = sizeof(struct sockaddr);
   so_mask.sa_family = AF_INET;


### PR DESCRIPTION
OpenBSD supports multiple routing tables. The current code doesn't account for that and instead always request the default gateway for routing table 0. This makes interacions with the library seem stuck as it tries to contact a gateway that might be in another network.

Additional details can be found in:

- https://marc.info/?l=openbsd-ports&m=172260911421348&w=2 for some testing of the patch
- https://man.openbsd.org/rtable.4 for the mechanism in question
- https://man.openbsd.org/route.4#The_Routing_Socket for the fields in `struct rt_msghdr`, which includes the field that the patches set and isn't present in other BSDs