### PR TITLE
Improve cmake install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ if (WIN32)
 endif (WIN32)
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
+option(BUILD_EXECUTABLES "Build executables" ON)
 
 # Library itself
 add_library(natpmp ${NATPMP_SOURCES})
@@ -38,24 +39,30 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Haiku")
 	target_link_libraries(natpmp PUBLIC network)
 endif ()
 
-# Executables
-add_executable(natpmpc natpmpc.c)
-target_link_libraries(natpmpc natpmp)
+if(BUILD_EXECUTABLES)
+	# Executables
+	add_executable(natpmpc natpmpc.c)
+	target_link_libraries(natpmpc natpmp)
 
-add_executable(testgetgateway
-	testgetgateway.c
-	getgateway.c)
-target_link_libraries(testgetgateway natpmp)
+	add_executable(testgetgateway
+		testgetgateway.c
+		getgateway.c)
+	target_link_libraries(testgetgateway natpmp)
+endif()
 
 # natpmp.pc
 include(GNUInstallDirs)
 configure_file(natpmp.pc.in natpmp.pc @ONLY)
 
 # install
-install(TARGETS natpmp natpmpc
+install(TARGETS natpmp
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+if(BUILD_EXECUTABLES)
+        install(TARGETS natpmpc DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 
 install(FILES natpmp.h natpmp_declspec.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ install(TARGETS natpmp natpmpc
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-install(FILES natpmp.h
+install(FILES natpmp.h natpmp_declspec.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/natpmp.pc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ option(BUILD_EXECUTABLES "Build executables" ON)
 
 # Library itself
 add_library(natpmp ${NATPMP_SOURCES})
-target_include_directories(natpmp PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+target_include_directories(natpmp PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> $<INSTALL_INTERFACE:include>)
 target_compile_definitions(natpmp PRIVATE -DENABLE_STRNATPMPERR)
 
 if (WIN32)
@@ -56,12 +56,15 @@ configure_file(natpmp.pc.in natpmp.pc @ONLY)
 
 # install
 install(TARGETS natpmp
+        EXPORT libnatpmp-targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 if(BUILD_EXECUTABLES)
-        install(TARGETS natpmpc DESTINATION ${CMAKE_INSTALL_BINDIR})
+        install(TARGETS natpmpc
+                EXPORT libnatpmp-targets
+                DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 install(FILES natpmp.h natpmp_declspec.h
@@ -70,3 +73,19 @@ install(FILES natpmp.h natpmp_declspec.h
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/natpmp.pc
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/libnatpmp-config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/libnatpmp-config.cmake"
+  INSTALL_DESTINATION "share/libnatpmp"
+)
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/libnatpmp-config.cmake"
+  DESTINATION "share/libnatpmp"
+)
+
+install(
+    EXPORT libnatpmp-targets
+    DESTINATION share/libnatpmp
+    NAMESPACE libnatpmp::
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,10 @@ if (WIN32)
 	target_link_libraries(natpmp PUBLIC ws2_32 iphlpapi)
 	if (BUILD_SHARED_LIBS)
 		target_compile_definitions(natpmp PUBLIC -DNATPMP_EXPORTS)
+		set(EXTRA_PKGCONFIG_CFLAGS "")
 	else() # win static lib
 		target_compile_definitions(natpmp PUBLIC -DNATPMP_STATICLIB)
+		set(EXTRA_PKGCONFIG_CFLAGS "-DNATPMP_STATICLIB")
 	endif (BUILD_SHARED_LIBS)
 endif (WIN32)
 

--- a/libnatpmp-config.cmake.in
+++ b/libnatpmp-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/libnatpmp-targets.cmake")
+
+check_required_components(libnatpmp)

--- a/natpmp.pc.in
+++ b/natpmp.pc.in
@@ -7,4 +7,4 @@ Name: libnatpmp
 Description: NAT-PMP client library
 Version: @PROJECT_VERSION@
 Libs: -L${libdir} -lnatpmp
-Cflags: -I${includedir}
+Cflags: -I${includedir} @EXTRA_PKGCONFIG_CFLAGS@


### PR DESCRIPTION
Some changes to make the cmake install steps useful.

I'm making these changes because we've started using libnatpmp over at [OpenOMF](https://github.com/omf2097/openomf/), and I maintain the MSVC build there (with dependencies built via vcpkg).