### PR TITLE
Avoid truncating Windows SOCKET to int

### DIFF
--- a/natpmp.c
+++ b/natpmp.c
@@ -73,12 +73,14 @@ NATPMP_LIBSPEC int initnatpmp(natpmp_t * p, int forcegw, in_addr_t forcedgw)
 		return NATPMP_ERR_INVALIDARGS;
 	memset(p, 0, sizeof(natpmp_t));
 	p->s = socket(PF_INET, SOCK_DGRAM, 0);
-	if(p->s < 0)
-		return NATPMP_ERR_SOCKETERROR;
 #ifdef _WIN32
+	if(p->s == INVALID_SOCKET)
+		return NATPMP_ERR_SOCKETERROR;
 	if(ioctlsocket(p->s, FIONBIO, &ioctlArg) == SOCKET_ERROR)
 		return NATPMP_ERR_FCNTLERROR;
 #else
+	if(p->s < 0)
+		return NATPMP_ERR_SOCKETERROR;
 	if((flags = fcntl(p->s, F_GETFL, 0)) < 0)
 		return NATPMP_ERR_FCNTLERROR;
 	if(fcntl(p->s, F_SETFL, flags | O_NONBLOCK) < 0)

--- a/natpmp.h
+++ b/natpmp.h
@@ -59,7 +59,11 @@ typedef unsigned short uint16_t;
 #endif
 
 typedef struct {
-	int s;	/* socket */
+#ifdef _WIN32
+	SOCKET s; /* socket */
+#else
+	int s; /* socket */
+#endif
 	in_addr_t gateway;	/* default gateway (IPv4) */
 	int has_pending_request;
 	unsigned char pending_request[12];


### PR DESCRIPTION
Winsock's SOCKET typedef is as wide as a pointer (it's a typedef of UINT_PTR), but libnatpmp implicitly casts it to an int (as other platform's sockets are ints.)

This is a soundness issue, as despite winsock usually returning small values like 0x00000000000000C8, we have no guarantee that a winsock SOCKET can be safely truncated to an int.
