### PR TITLE
build: install `natpmp_declspec.h`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ install(TARGETS natpmp natpmpc
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-install(FILES natpmp.h
+install(FILES natpmp.h natpmp_declspec.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/natpmp.pc


### PR DESCRIPTION
Since `natpmp.h` includes this file, this is the bare minimum for any builds that uses the installed libnatpmp to work.

You'll notice that this PR is a subset of #48.